### PR TITLE
Created a new statistics file on each run instead of 1 file for all runs in the same machine in order to resolve JSON validity issue. Also removed the salt from the file name since it is not the deployment's salt but a different, momentary salt.

### DIFF
--- a/deploy/modules/statistics/main.tf
+++ b/deploy/modules/statistics/main.tf
@@ -11,7 +11,6 @@ data "aws_caller_identity" "current" {}
 locals {
   statistics_cmds = templatefile("${path.module}/statistics.tpl", {
     statistics_bucket_name = "04274532-55f0-11ed-bdc3-0242ac120002"
-    salt                   = module.globals.salt
     ip                     = module.globals.my_ip
     account_id             = data.aws_caller_identity.current.account_id
     user_id                = data.aws_caller_identity.current.user_id

--- a/deploy/modules/statistics/statistics.tpl
+++ b/deploy/modules/statistics/statistics.tpl
@@ -7,7 +7,8 @@ then
   me=$(whoami)
   example_path=$(pwd)
 
-  file_name=$me-${salt}.gitignore.txt
+  # Include epoch seconds in file name to differentiate between different terraform runs in the same machine
+  file_name=$me-`date +%s`.gitignore.txt
 
   cat <<EOT >> $file_name
 {"date": "$now", "path": "$example_path", "ip": "${ip}", "account_id": "${account_id}", "user_id": "${user_id}", "whoami": "$me", "user_arn": "${user_arn}"}
@@ -15,7 +16,7 @@ EOT
 
   aws s3 cp $file_name s3://${statistics_bucket_name}/$file_name
 else
-  echo "Statistics won't be sent to Imperva - AWS CLI is not intalled on your machine"
+  echo "Statistics won't be sent to Imperva - AWS CLI is not installed on your machine"
   exit 0
 fi
 


### PR DESCRIPTION
Created a new statistics file on each run instead of 1 file for all runs in the same machine in order to resolve JSON validity issue. Also removed the salt from the file name since it is not the deployment's salt but a different, momentary salt.