### PR TITLE
SON-1270 Hub HADR error fails the DSFKit deployment (10 GWs, 2 GWs)

### DIFF
--- a/.github/workflows/terraform_apply_cli.yml
+++ b/.github/workflows/terraform_apply_cli.yml
@@ -40,7 +40,7 @@ env:
   TF_WARN_OUTPUT_ERRORS: 1
   TF_CLI_ARGS: "-no-color"
   TF_INPUT: 0
-  TF_VAR_gw_count: 2
+  TF_VAR_gw_count: 10
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/modules/null/hadr/main.tf
+++ b/modules/null/hadr/main.tf
@@ -56,7 +56,7 @@ resource "null_resource" "exec_hadr_secondary" {
 }
 
 resource "time_sleep" "sleep" {
-  create_duration = "120s"
+  create_duration = "300s"
   depends_on = [
     null_resource.exec_hadr_secondary
   ]


### PR DESCRIPTION
Increased timeout before check-2hadr-replica-set from 2 to 5 minutes