### PR TITLE
Fix cloud init timeout and logs

### DIFF
--- a/modules/aws/agentless-gw/main.tf
+++ b/modules/aws/agentless-gw/main.tf
@@ -61,5 +61,6 @@ module "gw_instance" {
   volume_attachment_device_name     = var.volume_attachment_device_name
   tags                              = var.tags
   base_directory                    = var.base_directory
+  cloud_init_timeout                = var.cloud_init_timeout
   send_usage_statistics             = var.send_usage_statistics
 }

--- a/modules/aws/agentless-gw/variables.tf
+++ b/modules/aws/agentless-gw/variables.tf
@@ -260,6 +260,12 @@ variable "base_directory" {
   description = "The base directory where all Sonar related directories will be installed"
 }
 
+variable "cloud_init_timeout" {
+  type        = number
+  default     = 900
+  description = "Max time to wait for the machine to start"
+}
+
 variable "send_usage_statistics" {
   type        = bool
   default     = true

--- a/modules/aws/hub/main.tf
+++ b/modules/aws/hub/main.tf
@@ -70,5 +70,6 @@ module "hub_instance" {
   volume_attachment_device_name     = var.volume_attachment_device_name
   tags                              = var.tags
   base_directory                    = var.base_directory
+  cloud_init_timeout                = var.cloud_init_timeout
   send_usage_statistics             = var.send_usage_statistics
 }

--- a/modules/aws/hub/variables.tf
+++ b/modules/aws/hub/variables.tf
@@ -323,6 +323,12 @@ variable "base_directory" {
   description = "The base directory where all Sonar related directories will be installed"
 }
 
+variable "cloud_init_timeout" {
+  type        = number
+  default     = 900
+  description = "Max time to wait for the machine to start"
+}
+
 variable "send_usage_statistics" {
   type        = bool
   default     = true

--- a/modules/aws/sonar-base-instance/userdata.tf
+++ b/modules/aws/sonar-base-instance/userdata.tf
@@ -57,7 +57,7 @@ resource "null_resource" "readiness" {
 
   provisioner "remote-exec" {
     inline = [
-      "if ! sudo timeout 3600 cloud-init status --wait | grep done &>/dev/null; then",
+      "if ! sudo timeout ${var.cloud_init_timeout} cloud-init status --wait | grep done &>/dev/null; then",
       "  ([[ -f /var/log/cloud-init-output.log ]] && sudo cat /var/log/cloud-init-output.log) || sudo grep cloud-init /var/log/messages;",
       "  echo;",
       "  sudo cloud-init status;",

--- a/modules/aws/sonar-base-instance/userdata.tf
+++ b/modules/aws/sonar-base-instance/userdata.tf
@@ -57,8 +57,8 @@ resource "null_resource" "readiness" {
 
   provisioner "remote-exec" {
     inline = [
-      "if ! sudo timeout 900 cloud-init status --wait | grep done &>/dev/null; then",
-      "  cat /var/log/cloud-init-output.log;",
+      "if ! sudo timeout 3600 cloud-init status --wait | grep done &>/dev/null; then",
+      "  ([[ -f /var/log/cloud-init-output.log ]] && sudo cat /var/log/cloud-init-output.log) || sudo grep cloud-init /var/log/messages;",
       "  echo;",
       "  sudo cloud-init status;",
       "  exit 1;",

--- a/modules/aws/sonar-base-instance/variables.tf
+++ b/modules/aws/sonar-base-instance/variables.tf
@@ -231,6 +231,12 @@ variable "base_directory" {
   description = "The base directory where all Sonar related directories will be installed"
 }
 
+variable "cloud_init_timeout" {
+  type        = number
+  default     = 900
+  description = "Max time to wait for the machine to start"
+}
+
 variable "send_usage_statistics" {
   type        = bool
   description = "Set to true to send usage statistics."

--- a/modules/azurerm/agentless-gw/main.tf
+++ b/modules/azurerm/agentless-gw/main.tf
@@ -58,5 +58,6 @@ module "gw_instance" {
   sonarw_private_key_secret_name    = var.sonarw_private_key_secret_name
   sonarw_public_key_content         = var.sonarw_public_key_content
   tags                              = var.tags
+  cloud_init_timeout                = var.cloud_init_timeout
   send_usage_statistics             = var.send_usage_statistics
 }

--- a/modules/azurerm/agentless-gw/variables.tf
+++ b/modules/azurerm/agentless-gw/variables.tf
@@ -224,6 +224,12 @@ variable "sonarw_public_key_content" {
   description = "The Agentless Gateway sonarw user SSH public key - used for remote Agentless Gateway federation, HADR, etc."
 }
 
+variable "cloud_init_timeout" {
+  type        = number
+  default     = 900
+  description = "Max time to wait for the machine to start"
+}
+
 variable "send_usage_statistics" {
   type        = bool
   default     = true

--- a/modules/azurerm/hub/main.tf
+++ b/modules/azurerm/hub/main.tf
@@ -67,5 +67,6 @@ module "hub_instance" {
   sonarw_private_key_secret_name    = var.sonarw_private_key_secret_name
   sonarw_public_key_content         = var.sonarw_public_key_content
   tags                              = var.tags
+  cloud_init_timeout                = var.cloud_init_timeout
   send_usage_statistics             = var.send_usage_statistics
 }

--- a/modules/azurerm/hub/variables.tf
+++ b/modules/azurerm/hub/variables.tf
@@ -273,6 +273,12 @@ variable "mx_details" {
   default = []
 }
 
+variable "cloud_init_timeout" {
+  type        = number
+  default     = 900
+  description = "Max time to wait for the machine to start"
+}
+
 variable "send_usage_statistics" {
   type        = bool
   default     = true

--- a/modules/azurerm/sonar-base-instance/userdata.tf
+++ b/modules/azurerm/sonar-base-instance/userdata.tf
@@ -57,7 +57,7 @@ resource "null_resource" "readiness" {
 
   provisioner "remote-exec" {
     inline = [
-      "if ! sudo timeout 3600 cloud-init status --wait | grep done &>/dev/null; then",
+      "if ! sudo timeout ${var.cloud_init_timeout} cloud-init status --wait | grep done &>/dev/null; then",
       "  ([[ -f /var/log/cloud-init-output.log ]] && sudo cat /var/log/cloud-init-output.log) || sudo grep cloud-init /var/log/messages;",
       "  echo;",
       "  sudo cloud-init status;",

--- a/modules/azurerm/sonar-base-instance/userdata.tf
+++ b/modules/azurerm/sonar-base-instance/userdata.tf
@@ -57,8 +57,8 @@ resource "null_resource" "readiness" {
 
   provisioner "remote-exec" {
     inline = [
-      "if ! sudo timeout 1200 cloud-init status --wait | grep done &>/dev/null; then",
-      "  cat /var/log/cloud-init-output.log;",
+      "if ! sudo timeout 3600 cloud-init status --wait | grep done &>/dev/null; then",
+      "  ([[ -f /var/log/cloud-init-output.log ]] && sudo cat /var/log/cloud-init-output.log) || sudo grep cloud-init /var/log/messages;",
       "  echo;",
       "  sudo cloud-init status;",
       "  exit 1;",

--- a/modules/azurerm/sonar-base-instance/variables.tf
+++ b/modules/azurerm/sonar-base-instance/variables.tf
@@ -202,6 +202,12 @@ variable "generate_access_tokens" {
   description = "Generate access tokens for connecting to USC / connect DAM to the DSF Hub"
 }
 
+variable "cloud_init_timeout" {
+  type        = number
+  default     = 900
+  description = "Max time to wait for the machine to start"
+}
+
 variable "send_usage_statistics" {
   type        = bool
   description = "Set to true to send usage statistics."


### PR DESCRIPTION
File `/var/log/cloud-init-output.log` does not exist in rhel7 or above, and instead is logged to /var/log/messages.

As well, I've had machines take up to 30 minutes to fully finish the cloud-init, so 15 minutes is not a long enough timeout. It has been increased to an hour to allow for extra variability in that startup time.