### PR TITLE
use existing 128 disk size, instead of partial disks

### DIFF
--- a/modules/azurerm/sonar-base-instance/main.tf
+++ b/modules/azurerm/sonar-base-instance/main.tf
@@ -3,7 +3,7 @@ locals {
   private_ip = azurerm_linux_virtual_machine.dsf_base_instance.private_ip_address
 
   # root volume details
-  root_volume_size  = 100
+  root_volume_size  = 128
   root_volume_type  = "Standard_LRS"
   root_volume_cache = "ReadWrite"
 

--- a/modules/azurerm/sonar-base-instance/variables.tf
+++ b/modules/azurerm/sonar-base-instance/variables.tf
@@ -77,8 +77,8 @@ variable "storage_details" {
   })
   description = "Compute instance external volume attributes"
   validation {
-    condition     = var.storage_details.disk_size >= 150
-    error_message = "Disk size must be at least 150 GB"
+    condition     = var.storage_details.disk_size >= 128
+    error_message = "Disk size must be at least 128 GB"
   }
 }
 


### PR DESCRIPTION
Azure bills in base 2 disk sizes, so 100GB costs the same as 128GB, and a 150GB drive would cost the same as a 256GB drive.