### PR TITLE
simplify remote executor

### DIFF
--- a/modules/aws/sonar-upgrader/python_upgrader/tests/test_main.py
+++ b/modules/aws/sonar-upgrader/python_upgrader/tests/test_main.py
@@ -81,8 +81,13 @@ def test_connection_mock(mocker):
     yield mocker.patch('upgrade.main.test_connection')
 
 
+@pytest.fixture
+def run_remote_script_mock(mocker):
+    yield mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects())
+
+
 @pytest.fixture(autouse=True)
-def setup_for_each_test(mocker, upgrade_status_service_mock, test_connection_mock):
+def setup_for_each_test(mocker, upgrade_status_service_mock, test_connection_mock, run_remote_script_mock):
     set_global_variables(100)
 
     mocker.patch('upgrade.main.join_paths', side_effect=lambda arg1, arg2, arg3: arg3)
@@ -91,10 +96,9 @@ def setup_for_each_test(mocker, upgrade_status_service_mock, test_connection_moc
     yield
 
 
-def test_main_all_flags_disabled(args, mocker):
+def test_main_all_flags_disabled(args, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}], [{"main": hub1}], False, False, False, False, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script')
 
     # when
     main(args)
@@ -103,11 +107,9 @@ def test_main_all_flags_disabled(args, mocker):
     run_remote_script_mock.assert_not_called()
 
 
-def test_main_all_flags_enabled(args, mocker):
+def test_main_all_flags_enabled(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}], [{"main": hub1}], True, True, True, True, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script',
-                                          side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -123,10 +125,9 @@ def test_main_all_flags_enabled(args, mocker):
         assert count_remote_calls_with_host_and_script(call_args_list, host, "run_postflight_validations.py") == 1
 
 
-def test_main_only_test_connection_enabled(args, mocker):
+def test_main_only_test_connection_enabled(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}], [{"main": hub1}], True, False, False, False, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script')
 
     # when
     main(args)
@@ -136,11 +137,9 @@ def test_main_only_test_connection_enabled(args, mocker):
     run_remote_script_mock.assert_not_called()
 
 
-def test_main_only_preflight_enabled(args, mocker):
+def test_main_only_preflight_enabled(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}], [{"main": hub1}], False, True, False, False, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script',
-                                          side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -155,11 +154,9 @@ def test_main_only_preflight_enabled(args, mocker):
     assert count_remote_calls_with_host_and_script(call_args_list, "host100", "run_preflight_validations.py") == 1
 
 
-def test_main_only_upgrade_enabled(args, mocker):
+def test_main_only_upgrade_enabled(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}], [{"main": hub1}], False, False, True, False, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script',
-                                          side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -172,11 +169,9 @@ def test_main_only_upgrade_enabled(args, mocker):
     assert count_remote_calls_with_host_and_script(call_args_list, "host100", "upgrade_v4_10.sh") == 1
 
 
-def test_main_only_postflight_enabled(args, mocker):
+def test_main_only_postflight_enabled(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}], [{"main": hub1}], False, False, False, True, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script',
-                                          side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -191,12 +186,10 @@ def test_main_only_postflight_enabled(args, mocker):
     assert count_remote_calls_with_host_and_script(call_args_list, "host100", "run_postflight_validations.py") == 1
 
 
-def test_main_custom_tarball(args, mocker):
+def test_main_custom_tarball(args, test_connection_mock, run_remote_script_mock):
     # given
     tarball_location = '{"s3_bucket": "my_custom_bucket", "s3_region": "my_custom_region"}'
     setup_custom_args(args, [{"main": gw1}], [], True, True, True, True, True, tarball_location=tarball_location)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script',
-                                          side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -209,23 +202,20 @@ def test_main_custom_tarball(args, mocker):
     assert count_remote_calls_with_host_and_script(call_args_list, "host1", "run_postflight_validations.py") == 1
     assert count_remote_calls_with_host_and_script(call_args_list, "host1", "upgrade_v4_10.sh") == 1
     assert count_remote_calls_with_host_and_script(call_args_list, "host1", "run_postflight_validations.py") == 1
-    assert "my_custom_bucket" in call_args_list[2].args[4]
-    assert "my_custom_region" in call_args_list[2].args[4]
+    assert "my_custom_bucket" in call_args_list[2].args[2]
+    assert "my_custom_region" in call_args_list[2].args[2]
 
 
-def test_main_host_with_proxy(args, mocker):
+def test_main_host_with_proxy(args, run_remote_script_mock, test_connection_mock):
     # given
     setup_custom_args(args, [{"main": gw3}], [], True, True, True, True, True)
-    test_connection_via_proxy_mock = mocker.patch('upgrade.main.test_connection_via_proxy')
-    run_remote_script_via_proxy_mock = mocker.patch('upgrade.main.run_remote_script_via_proxy',
-                                          side_effect=create_mocked_run_remote_script_with_proxy_side_effects())
 
     # when
     main(args)
 
     # then
-    assert test_connection_via_proxy_mock.call_count == 1
-    call_args_list = run_remote_script_via_proxy_mock.call_args_list
+    assert test_connection_mock.call_count == 1
+    call_args_list = run_remote_script_mock.call_args_list
     assert len(call_args_list) == 4
     assert count_remote_calls_with_host_and_script(call_args_list, "host3", "get_python_location.sh") == 1
     assert count_remote_calls_with_host_and_script(call_args_list, "host3", "run_postflight_validations.py") == 1
@@ -233,7 +223,7 @@ def test_main_host_with_proxy(args, mocker):
     assert count_remote_calls_with_host_and_script(call_args_list, "host3", "run_postflight_validations.py") == 1
 
 
-def test_main_skip_successful_host(args, upgrade_status_service_mock, test_connection_mock, mocker):
+def test_main_skip_successful_host(args, upgrade_status_service_mock, test_connection_mock, run_remote_script_mock, mocker):
     # given
     setup_custom_args(args, [{"main": gw1}, {"main": gw2}], [], True, True, True, True, True)
     mocker.patch.object(upgrade_status_service_mock, 'should_test_connection', side_effect=lambda host: host == "host2")
@@ -241,7 +231,6 @@ def test_main_skip_successful_host(args, upgrade_status_service_mock, test_conne
     mocker.patch.object(upgrade_status_service_mock, 'should_run_preflight_validations', side_effect=lambda host: host == "host2")
     mocker.patch.object(upgrade_status_service_mock, 'should_run_upgrade', side_effect=lambda host: host == "host2")
     mocker.patch.object(upgrade_status_service_mock, 'should_run_postflight_validations', side_effect=lambda host: host == "host2")
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -261,12 +250,14 @@ def test_main_skip_successful_host(args, upgrade_status_service_mock, test_conne
     ([], ["host1"]),
 ])
 def test_main_preflight_failure_with_stop_on_failure_true(
-        args, test_connection_mock, mocker,
+        args, test_connection_mock, run_remote_script_mock,
         preflight_not_pass_hosts, preflight_error_hosts):
     # given
     setup_custom_args(args, [{"main": gw1}, {"main": gw2}], [{"main": hub1}], True, True, True, True, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        preflight_validations_not_pass_hosts=preflight_not_pass_hosts, preflight_validations_error_hosts=preflight_error_hosts))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(
+        preflight_validations_not_pass_hosts=preflight_not_pass_hosts,
+        preflight_validations_error_hosts=preflight_error_hosts,
+    )
 
     # when
     main(args)
@@ -280,11 +271,10 @@ def test_main_preflight_failure_with_stop_on_failure_true(
     assert count_remote_calls_with_host_and_script(call_args_list, "host1", "run_preflight_validations.py") == 1
 
 
-def test_main_upgrade_failure_with_stop_on_failure_true(args, test_connection_mock, mocker):
+def test_main_upgrade_failure_with_stop_on_failure_true(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1}, {"main": gw2}], [{"main": hub1}], True, True, True, True, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        upgrade_error_hosts=["host1"]))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(upgrade_error_hosts=["host1"])
 
     # when
     main(args)
@@ -300,11 +290,10 @@ def test_main_upgrade_failure_with_stop_on_failure_true(args, test_connection_mo
 
 
 def test_main_python_location_failure_with_stop_on_failure_false(
-        args, upgrade_status_service_mock, test_connection_mock, mocker):
+        args, upgrade_status_service_mock, test_connection_mock, run_remote_script_mock, mocker):
     # given
     setup_custom_args(args, [{"main": gw1}, {"main": gw2}], [{"main": hub1}], True, True, True, True, False)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        python_location_error_hosts=["host1"]))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(python_location_error_hosts=["host1"])
     mocker.patch.object(upgrade_status_service_mock, 'should_run_preflight_validations', side_effect=lambda host: host != "host1")
     mocker.patch.object(upgrade_status_service_mock, 'should_run_upgrade', side_effect=lambda host: host != "host1")
     mocker.patch.object(upgrade_status_service_mock, 'should_run_postflight_validations', side_effect=lambda host: host != "host1")
@@ -329,12 +318,14 @@ def test_main_python_location_failure_with_stop_on_failure_false(
     ([], ["host1"]),
 ])
 def test_main_preflight_failure_with_stop_on_failure_false(
-        args, upgrade_status_service_mock, test_connection_mock, mocker,
-        preflight_not_pass_hosts, preflight_error_hosts):
+        args, upgrade_status_service_mock, test_connection_mock, run_remote_script_mock,
+        mocker, preflight_not_pass_hosts, preflight_error_hosts):
     # given
     setup_custom_args(args, [{"main": gw1}, {"main": gw2}], [{"main": hub1}], True, True, True, True, False)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        preflight_validations_not_pass_hosts=preflight_not_pass_hosts, preflight_validations_error_hosts=preflight_error_hosts))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(
+        preflight_validations_not_pass_hosts=preflight_not_pass_hosts,
+        preflight_validations_error_hosts=preflight_error_hosts,
+    )
     mocker.patch.object(upgrade_status_service_mock, 'should_run_upgrade', side_effect=lambda host: host != "host1")
     mocker.patch.object(upgrade_status_service_mock, 'should_run_postflight_validations', side_effect=lambda host: host != "host1")
 
@@ -353,10 +344,9 @@ def test_main_preflight_failure_with_stop_on_failure_false(
         assert count_remote_calls_with_host_and_script(call_args_list, host, "run_postflight_validations.py") == 1
 
 
-def test_main_hadr_set_successful(args, test_connection_mock, mocker):
+def test_main_hadr_set_successful(args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1, "dr": gw2}], [{"main": hub1, "dr": hub2, "minor": hub3}], True, True, True, True, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects())
 
     # when
     main(args)
@@ -373,11 +363,10 @@ def test_main_hadr_set_successful(args, test_connection_mock, mocker):
 
 
 def test_main_hadr_set_skip_node_after_hadr_upgrade_failure_stop_on_failure_false(
-        args, test_connection_mock, mocker):
+        args, test_connection_mock, run_remote_script_mock):
     # given
     setup_custom_args(args, [{"main": gw1, "dr": gw2}], [{"main": hub1, "dr": hub2, "minor": hub3}], True, True, True, True, False)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        upgrade_error_hosts=["host2", "host102"]))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(upgrade_error_hosts=["host2", "host102"])
 
     # when
     main(args)
@@ -395,15 +384,17 @@ def test_main_hadr_set_skip_node_after_hadr_upgrade_failure_stop_on_failure_fals
 
 @pytest.mark.parametrize("postflight_not_pass_hosts, postflight_error_hosts", [
     (["host2", "host102"], []),
-    # ([], ["host2", "host102"]),
+    ([], ["host2", "host102"]),
 ])
 def test_main_hadr_set_skip_node_after_hadr_postflight_failure_stop_on_failure_false(
-        args, test_connection_mock, mocker,
+        args, test_connection_mock, run_remote_script_mock,
         postflight_not_pass_hosts, postflight_error_hosts):
     # given
     setup_custom_args(args, [{"main": gw1, "dr": gw2}], [{"main": hub1, "dr": hub2, "minor": hub3}], True, True, True, True, False)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        postflight_validations_not_pass_hosts=postflight_not_pass_hosts, postflight_validations_error_hosts=postflight_error_hosts))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(
+        postflight_validations_not_pass_hosts=postflight_not_pass_hosts,
+        postflight_validations_error_hosts=postflight_error_hosts,
+    )
 
     # when
     main(args)
@@ -422,11 +413,11 @@ def test_main_hadr_set_skip_node_after_hadr_postflight_failure_stop_on_failure_f
 
 
 @pytest.mark.xfail(raises=UpgradeException)
-def test_main_raise_exception_on_overall_status_failed(args, upgrade_status_service_mock, test_connection_mock, mocker):
+def test_main_raise_exception_on_overall_status_failed(
+        args, upgrade_status_service_mock, test_connection_mock, run_remote_script_mock, mocker):
     # given
     setup_custom_args(args, [{"main": gw1}], [], True, True, True, True, True)
-    run_remote_script_mock = mocker.patch('upgrade.main.run_remote_script', side_effect=create_mocked_run_remote_script_side_effects(
-        python_location_error_hosts=["host1"]))
+    run_remote_script_mock.side_effect = create_mocked_run_remote_script_side_effects(python_location_error_hosts=["host1"])
     mocker.patch.object(upgrade_status_service_mock, 'get_overall_upgrade_status', return_value=OverallUpgradeStatus.FAILED)
 
     # when
@@ -458,8 +449,8 @@ def create_mocked_run_remote_script_side_effects(python_location_error_hosts=Non
                                                  upgrade_error_hosts=None,
                                                  postflight_validations_not_pass_hosts=None,
                                                  postflight_validations_error_hosts=None):
-    def mocked_run_remote_script(host, remote_user, remote_key_filename, script_contents, script_run_command,
-                                 connection_timeout):
+    def mocked_run_remote_script(dsf_node, script_contents, script_run_command):
+        host = dsf_node.get('host')
         if "get_python_location.sh" in script_contents:
             if python_location_error_hosts is not None and host in python_location_error_hosts:
                 return "get_python_location error"
@@ -491,14 +482,5 @@ def create_mocked_run_remote_script_side_effects(python_location_error_hosts=Non
     return mocked_run_remote_script
 
 
-def create_mocked_run_remote_script_with_proxy_side_effects():
-    mocked_run_remote_script = create_mocked_run_remote_script_side_effects()
-    def mocked_run_remote_with_proxy_script(host, remote_user, remote_key_filename, script_contents, script_run_command,
-                                            proxy_host, proxy_user, proxy_key_filename, connection_timeout):
-        return mocked_run_remote_script(host, remote_user, remote_key_filename, script_contents, script_run_command,
-                                        connection_timeout)
-    return mocked_run_remote_with_proxy_script
-
-
 def count_remote_calls_with_host_and_script(call_args_list, host, script_content):
-    return sum(1 for call_args in call_args_list if call_args.args[0] == host and script_content in call_args.args[3])
+    return sum(1 for call_args in call_args_list if call_args.args[0].get('host') == host and script_content in call_args.args[2])

--- a/modules/aws/sonar-upgrader/python_upgrader/upgrade/main.py
+++ b/modules/aws/sonar-upgrader/python_upgrader/upgrade/main.py
@@ -8,7 +8,7 @@ import os
 from itertools import chain
 
 from .utils.file_utils import join_paths, read_file_contents
-from .remote_executor import remote_client_context, run_remote_script
+from .remote_executor import remote_client_context, run_remote_script as run_remote_script_timeout
 from .upgrade_status_service import UpgradeStatusService, UpgradeStatus, OverallUpgradeStatus
 from .upgrade_exception import UpgradeException
 
@@ -162,8 +162,8 @@ def build_python_script_run_command(script_contents, args, python_location):
     return f"sudo {python_location} -c '{script_contents}' {args}"
 
 
-def run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_command):
-    return run_remote_script(dsf_node, script_contents, script_run_command, _connection_timeout)
+def run_remote_script(dsf_node, script_contents, script_run_command):
+    return run_remote_script_timeout(dsf_node, script_contents, script_run_command, _connection_timeout)
 
 
 def test_connection(dsf_node):
@@ -442,7 +442,7 @@ def run_preflight_validations_script(target_version, dsf_node, dsf_node_name, py
     script_run_command = build_python_script_run_command(script_contents, target_version, python_location)
     # print(f"script_run_command: {script_run_command}")
 
-    script_output = run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_command)
+    script_output = run_remote_script(dsf_node, script_contents, script_run_command)
     print(f"'Run preflight validations' python script output:\n{script_output}")
 
     preflight_validations_result = json.loads(extract_preflight_validations_result(script_output))
@@ -456,7 +456,7 @@ def run_get_python_location_script(dsf_node):
     script_run_command = build_bash_script_run_command(script_contents)
 
     print(f"Getting python location for DSF node: {dsf_node}")
-    script_output = run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_command)
+    script_output = run_remote_script(dsf_node, script_contents, script_run_command)
 
     print(f"'Get python location' bash script output: {script_output}")
     return extract_python_location(script_output)
@@ -664,7 +664,7 @@ def run_upgrade_script(dsf_node, target_version, tarball_location, upgrade_scrip
     script_run_command = build_bash_script_run_command(script_contents, args)
     # print(f"script_run_command: {script_run_command}")
 
-    script_output = run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_command)
+    script_output = run_remote_script(dsf_node, script_contents, script_run_command)
 
     print(f"Upgrade bash script output: {script_output}")
     # This relies on the fact that Sonar outputs the string "Upgrade completed"
@@ -740,7 +740,7 @@ def run_postflight_validations_script(dsf_node, target_version, python_location,
     script_run_command = build_python_script_run_command(script_contents, target_version, python_location)
     # print(f"script_run_command: {script_run_command}")
 
-    script_output = run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_command)
+    script_output = run_remote_script(dsf_node, script_contents, script_run_command)
     print(f"'Run postflight validations' python script output: {script_output}")
     return extract_postflight_validations_result(script_output)
 
@@ -764,7 +764,7 @@ def run_clean_old_deployments_script(dsf_node, script_file_name):
     script_run_command = build_bash_script_run_command(script_contents)
     # print(f"script_run_command: {script_run_command}")
 
-    script_output = run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_command)
+    script_output = run_remote_script(dsf_node, script_contents, script_run_command)
 
     print(f"Cleaning old deployments bash script output: {script_output}")
     # TODO need to determine how to recognize that the clean command succeeded after implementing it

--- a/modules/aws/sonar-upgrader/python_upgrader/upgrade/main.py
+++ b/modules/aws/sonar-upgrader/python_upgrader/upgrade/main.py
@@ -166,7 +166,7 @@ def run_remote_script_maybe_with_proxy(dsf_node, script_contents, script_run_com
     return run_remote_script(dsf_node, script_contents, script_run_command, _connection_timeout)
 
 
-def test_connection_maybe_with_proxy(dsf_node):
+def test_connection(dsf_node):
     with remote_client_context(dsf_node, _connection_timeout) as client:
         client.exec_command('echo yes')
 
@@ -338,7 +338,7 @@ def test_connection_to_extended_node(extended_node, stop_on_failure, upgrade_sta
         print(f"Running test connection to {extended_node.get('dsf_node_name')}")
         upgrade_status_service.update_upgrade_status(extended_node.get('dsf_node_id'),
                                                      UpgradeStatus.RUNNING_TEST_CONNECTION)
-        test_connection_maybe_with_proxy(extended_node.get('dsf_node'))
+        test_connection(extended_node.get('dsf_node'))
         print(f"Test connection to {extended_node.get('dsf_node_name')} succeeded")
         upgrade_status_service.update_upgrade_status(extended_node.get('dsf_node_id'),
                                                      UpgradeStatus.TEST_CONNECTION_SUCCEEDED)

--- a/modules/aws/sonar-upgrader/python_upgrader/upgrade/remote_executor.py
+++ b/modules/aws/sonar-upgrader/python_upgrader/upgrade/remote_executor.py
@@ -4,8 +4,8 @@ from contextlib import contextmanager
 import paramiko
 
 
-def run_remote_script(extended_node, script_contents, script_run_command, connection_timeout):
-    with remote_client_context(extended_node, connection_timeout) as client:
+def run_remote_script(dsf_node, script_contents, script_run_command, connection_timeout):
+    with remote_client_context(dsf_node, connection_timeout) as client:
         print(f"Executing script (first 20 lines): {script_contents.strip().splitlines()[:20]}")
         stdin, stdout, stderr = client.exec_command(script_run_command)
 
@@ -16,11 +16,11 @@ def run_remote_script(extended_node, script_contents, script_run_command, connec
         return script_output
 
 
-def get_proxy_client_channel(extended_node, connection_timeout):
-    host = extended_node.get('host')
-    proxy_host = extended_node.get("proxy").get('host')
-    proxy_ssh_user = extended_node.get("proxy").get('ssh_user')
-    proxy_ssh_private_key_file_path = extended_node.get("proxy").get("ssh_private_key_file_path")
+def get_proxy_client_channel(dsf_node, connection_timeout):
+    host = dsf_node.get('host')
+    proxy_host = dsf_node.get("proxy").get('host')
+    proxy_ssh_user = dsf_node.get("proxy").get('ssh_user')
+    proxy_ssh_private_key_file_path = dsf_node.get("proxy").get("ssh_private_key_file_path")
 
     proxy_client = paramiko.SSHClient()
     try:
@@ -39,18 +39,18 @@ def get_proxy_client_channel(extended_node, connection_timeout):
 
 
 @contextmanager
-def remote_client_context(extended_node, connection_timeout):
+def remote_client_context(dsf_node, connection_timeout):
     proxy_client = None
 
-    host = extended_node.get('host')
-    ssh_user = extended_node.get('ssh_user')
-    ssh_private_key_file_path = extended_node.get('ssh_private_key_file_path')
+    host = dsf_node.get('host')
+    ssh_user = dsf_node.get('ssh_user')
+    ssh_private_key_file_path = dsf_node.get('ssh_private_key_file_path')
     client = paramiko.SSHClient()
 
     try:
         proxy_channel = None
-        if extended_node.get('proxy'):
-            proxy_client, proxy_channel = get_proxy_client_channel(extended_node, connection_timeout)
+        if dsf_node.get('proxy'):
+            proxy_client, proxy_channel = get_proxy_client_channel(dsf_node, connection_timeout)
 
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         client.connect(host, port=22, username=ssh_user, key_filename=ssh_private_key_file_path,


### PR DESCRIPTION
Related to https://onejira.imperva.com/browse/SD-1064

Standardize getting paramiko client. Create `remote_client_context` to return a client with or without proxy, and cleanup afterwards.

As well, added some `raise from` to improve debugging.


This is the prequal to using the paramiko client for more things, so simplifying how to create one is important.