### PR TITLE
Fix duplicate folder name

### DIFF
--- a/modules/aws/sonar-base-instance/setup.tftpl
+++ b/modules/aws/sonar-base-instance/setup.tftpl
@@ -161,7 +161,7 @@ function install_tarball() {
 
     echo Installing tarball..
     # Installing tarball
-    sudo tar -xf $TARBALL_FILE -gz -C $APPS_DIR
+    sudo tar -xf $TARBALL_FILE -gz -C $APPS_DIR --strip-components=2
     rm $TARBALL_FILE
     sudo chown -R sonarw:sonar $APPS_DIR
 }

--- a/modules/aws/sonar-base-instance/setup.tftpl
+++ b/modules/aws/sonar-base-instance/setup.tftpl
@@ -281,7 +281,13 @@ __EOF__
 DATA_DIR="${base_directory}/data"
 LOGS_DIR="${base_directory}/logs"
 LOCAL_DIR="${base_directory}/local"
-APPS_DIR="${base_directory}/apps"
+
+APPS_DIR="${base_directory}"
+if ! [[ $APPS_DIR =~ ^.*/jsonar/?$ ]]; then
+    # if does not end with jsonar folder, add jsonar to the end
+    APPS_DIR="$APPS_DIR/jsonar"
+fi
+APPS_DIR="$APPS_DIR/apps"
 
 install_deps
 create_users_and_groups

--- a/modules/aws/sonar-base-instance/setup.tftpl
+++ b/modules/aws/sonar-base-instance/setup.tftpl
@@ -184,7 +184,7 @@ verlt() {
 
 function setup() {
     set_instance_fqdn
-    VERSION=$(ls $APPS_DIR/jsonar/apps -Art | tail -1)
+    VERSION=$(ls $APPS_DIR -Art | tail -1)
     echo Setup sonar $VERSION
 
     password=$(/usr/local/bin/aws secretsmanager get-secret-value --secret-id ${password_secret} --query SecretString --output text)
@@ -195,7 +195,7 @@ function setup() {
         PRODUCT="data-security-fabric"
     fi
 
-    sudo $APPS_DIR/jsonar/apps/"$VERSION"/bin/sonarg-setup --no-interactive \
+    sudo "$APPS_DIR/$VERSION/bin/sonarg-setup" --no-interactive \
         --accept-eula \
         --jsonar-uid-display-name "${display_name}" \
         --product "$PRODUCT" \

--- a/modules/azurerm/sonar-base-instance/setup.tftpl
+++ b/modules/azurerm/sonar-base-instance/setup.tftpl
@@ -162,7 +162,7 @@ function install_tarball() {
 
     echo Installing tarball..
     # Installing tarball
-    sudo tar -xf $TARBALL_FILE -gz -C $APPS_DIR
+    sudo tar -xf $TARBALL_FILE -gz -C $APPS_DIR --strip-components=2
     rm $TARBALL_FILE
     sudo chown -R sonarw:sonar $APPS_DIR
 }

--- a/modules/azurerm/sonar-base-instance/setup.tftpl
+++ b/modules/azurerm/sonar-base-instance/setup.tftpl
@@ -185,7 +185,7 @@ verlt() {
 
 function setup() {
     set_instance_fqdn
-    VERSION=$(ls $APPS_DIR/jsonar/apps -Art | tail -1)
+    VERSION=$(ls "$APPS_DIR" -Art | tail -1)
     echo Setup sonar $VERSION
 
     password=$(az keyvault secret show --vault-name ${vault_name} --name ${password_secret} --query 'value' --output tsv)
@@ -196,7 +196,7 @@ function setup() {
         PRODUCT="data-security-fabric"
     fi
 
-    sudo $APPS_DIR/jsonar/apps/"$VERSION"/bin/sonarg-setup --no-interactive \
+    sudo "$APPS_DIR/$VERSION/bin/sonarg-setup" --no-interactive \
         --accept-eula \
         --jsonar-uid-display-name "${display_name}" \
         --product "$PRODUCT" \

--- a/modules/azurerm/sonar-base-instance/setup.tftpl
+++ b/modules/azurerm/sonar-base-instance/setup.tftpl
@@ -284,7 +284,13 @@ function firewall_open_ports() {
 DATA_DIR="${base_directory}/data"
 LOGS_DIR="${base_directory}/logs"
 LOCAL_DIR="${base_directory}/local"
-APPS_DIR="${base_directory}/apps"
+
+APPS_DIR="${base_directory}"
+if ! [[ $APPS_DIR =~ ^.*/jsonar/?$ ]]; then
+    # if does not end with jsonar folder, add jsonar to the end
+    APPS_DIR="$APPS_DIR/jsonar"
+fi
+APPS_DIR="$APPS_DIR/apps"
 
 install_deps
 firewall_open_ports || true


### PR DESCRIPTION
Don't duplicate the `apps` folder in the extract path.
Closes https://onejira.imperva.com/browse/SD-1301