### PR TITLE
changing upload-artifact ver from v2 to v4

### DIFF
--- a/.github/workflows/nightly_sonar_poc_basic_cli.yml
+++ b/.github/workflows/nightly_sonar_poc_basic_cli.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Collect Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: collected-keys
         path: |

--- a/.github/workflows/sonar_multi_account_cli.yml
+++ b/.github/workflows/sonar_multi_account_cli.yml
@@ -154,7 +154,7 @@ jobs:
       run: terraform -chdir=$EXAMPLE_DIR output -json
 
     - name: Collect Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: collected-keys
         path: |

--- a/.github/workflows/sonar_poc_cloud.yml
+++ b/.github/workflows/sonar_poc_cloud.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Collect Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: collected-keys
         path: |


### PR DESCRIPTION
i changed the version in action/upload-artifact from v2 to v4 because version v2 is deprecated and therefore causes workflow 'nightly_sonar_poc_basic_cli' to fail