### PR TITLE
ITP-5049: DRA machines deployed with DSFKit on AWS do not start after shutdown (all versions)

### DIFF
--- a/modules/aws/dra-admin/variables.tf
+++ b/modules/aws/dra-admin/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 
 variable "instance_type" {
   type        = string
-  default     = "m4.xlarge"
+  default     = "m5.xlarge"
   description = "EC2 instance type for the Admin Server"
 }
 

--- a/modules/aws/dra-analytics/variables.tf
+++ b/modules/aws/dra-analytics/variables.tf
@@ -107,7 +107,7 @@ variable "admin_server_public_ip" {
 
 variable "instance_type" {
   type        = string
-  default     = "m4.xlarge"
+  default     = "m5.xlarge"
   description = "EC2 instance type for the Analytics Server"
 }
 


### PR DESCRIPTION
fixed by changing instance type from "m4.xlarge" to "m5.xlarge"