### PR TITLE
fix: make zip file deletion more robust in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
             _d=$(dirname ${d})
             _b=$(basename ${d})
             pushd $_d
-            rm ${_b}/*.zip
+            rm -f ${_b}/*.zip
             mv ${_b} ${_b}_${{ steps.format-version.outputs.FORMATTED_VERSION }}
             zip -FSr ${_b}_${{ steps.format-version.outputs.FORMATTED_VERSION }}/${_b}_${{ steps.format-version.outputs.FORMATTED_VERSION }}.zip ${_b}_${{ steps.format-version.outputs.FORMATTED_VERSION }}
             mv ${_b}_${{ steps.format-version.outputs.FORMATTED_VERSION }} ${_b}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Zip Sonar python upgrader, remove old version zip
         run: |
-          rm modules/sonar_python_upgrader_*.zip
+          rm -f modules/sonar_python_upgrader_*.zip
           pushd modules/aws/sonar-upgrader
           mv python_upgrader sonar_python_upgrader_${{ steps.format-version.outputs.FORMATTED_VERSION }}
           zip -FSr ../../sonar_python_upgrader_${{ steps.format-version.outputs.FORMATTED_VERSION }}.zip sonar_python_upgrader_${{ steps.format-version.outputs.FORMATTED_VERSION }}


### PR DESCRIPTION
Use rm -f instead of rm to prevent workflow failures when zip files don't exist. This handles edge cases like:
- First-time releases of new examples
- Missing zip files from previous failed releases
- Any other scenarios where old zip files may not be present