### PR TITLE
feat: bump CipherTrust Manager default version to 2.22

### DIFF
--- a/.github/workflows/dsf_poc_cli.yml
+++ b/.github/workflows/dsf_poc_cli.yml
@@ -246,6 +246,7 @@ jobs:
             mv $EXAMPLE_DIR/cm.tf{,_}
             mv $EXAMPLE_DIR/cte_ddc_agents.tf{,_}
             mv $EXAMPLE_DIR/fam_classification_integration_resources.tf{,_}
+            mv $EXAMPLE_DIR/dns.tf{,_}
 
             # Try destroy first
             if ! terraform -chdir=$EXAMPLE_DIR destroy -var dam_license=license.mprv -auto-approve; then
@@ -268,6 +269,7 @@ jobs:
             mv $EXAMPLE_DIR/cm.tf{_,}
             mv $EXAMPLE_DIR/cte_ddc_agents.tf{_,}
             mv $EXAMPLE_DIR/fam_classification_integration_resources.tf{_,}
+            mv $EXAMPLE_DIR/dns.tf{_,}
           fi
 
       - name: Terraform Validate

--- a/.github/workflows/dsf_poc_cli.yml
+++ b/.github/workflows/dsf_poc_cli.yml
@@ -34,6 +34,12 @@ on:
         required: true
       PASSWORD:
         required: true
+      DNS_ZONE_DOMAIN:
+        required: true
+      DNS_ROUTE53_ROLE_ARN:
+        required: true
+      DNS_ROUTE53_ZONE_ID:
+        required: true
 
   workflow_dispatch:
     inputs:
@@ -146,6 +152,9 @@ jobs:
       TF_VAR_enable_dra: ${{ matrix.enable_dra }}
       TF_VAR_allowed_ssh_cidrs: ${{ vars.ALLOWED_SSH_CIDRS }}
       TF_VAR_password: ${{ secrets.PASSWORD }}
+      TF_VAR_dns_zone_domain: ${{ vars.DNS_ZONE_DOMAIN }}
+      TF_VAR_dns_route53_role_arn: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+      TF_VAR_dns_route53_zone_id: ${{ vars.DNS_ROUTE53_ZONE_ID }}
       DEPLOYMENT_VERSION: ${{ needs.prepare-matrix.outputs.deployment_version }}
 
       # Define the dynamic version string based on deployment_type and product_version

--- a/.github/workflows/dsf_poc_standalone.yml
+++ b/.github/workflows/dsf_poc_standalone.yml
@@ -31,6 +31,9 @@ jobs:
       DAM_LICENSE: ${{ secrets.DAM_LICENSE }}
       ALLOWED_SSH_CIDRS: ${{vars.ALLOWED_SSH_CIDRS }}
       DEPLOYMENT_TAGS: ${{ vars.DEPLOYMENT_TAGS }}
+      DNS_ZONE_DOMAIN: ${{ vars.DNS_ZONE_DOMAIN }}
+      DNS_ROUTE53_ROLE_ARN: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+      DNS_ROUTE53_ZONE_ID: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
   dsf_poc_azure:
     uses: imperva/dsfkit/.github/workflows/dsf_poc_cli_azure.yml@master

--- a/.github/workflows/nightly_manager.yml
+++ b/.github/workflows/nightly_manager.yml
@@ -61,6 +61,9 @@ jobs:
       ALLOWED_SSH_CIDRS: ${{vars.ALLOWED_SSH_CIDRS }}
       DEPLOYMENT_TAGS: ${{ vars.DEPLOYMENT_TAGS }}
       PASSWORD: ${{ secrets.PASSWORD }}
+      DNS_ZONE_DOMAIN: ${{ vars.DNS_ZONE_DOMAIN }}
+      DNS_ROUTE53_ROLE_ARN: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+      DNS_ROUTE53_ZONE_ID: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
   dev_dsf_poc:
     uses: imperva/dsfkit/.github/workflows/dsf_poc_cli.yml@dev
@@ -75,6 +78,9 @@ jobs:
       ALLOWED_SSH_CIDRS: ${{vars.ALLOWED_SSH_CIDRS }}
       DEPLOYMENT_TAGS: ${{ vars.DEPLOYMENT_TAGS }}
       PASSWORD: ${{ secrets.PASSWORD }}
+      DNS_ZONE_DOMAIN: ${{ vars.DNS_ZONE_DOMAIN }}
+      DNS_ROUTE53_ROLE_ARN: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+      DNS_ROUTE53_ZONE_ID: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
   master_dsf_poc_azure:
     uses: imperva/dsfkit/.github/workflows/dsf_poc_cli_azure.yml@master
@@ -113,6 +119,9 @@ jobs:
       DAM_LICENSE: ${{ secrets.DAM_LICENSE }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       DEPLOYMENT_TAGS: ${{ vars.DEPLOYMENT_TAGS }}
+      DNS_ZONE_DOMAIN: ${{ vars.DNS_ZONE_DOMAIN }}
+      DNS_ROUTE53_ROLE_ARN: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+      DNS_ROUTE53_ZONE_ID: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
   dev_sonar_upgrade:
     uses: imperva/dsfkit/.github/workflows/sonar_upgrade.yml@dev
@@ -125,3 +134,6 @@ jobs:
       DAM_LICENSE: ${{ secrets.DAM_LICENSE }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       DEPLOYMENT_TAGS: ${{ vars.DEPLOYMENT_TAGS }}
+      DNS_ZONE_DOMAIN: ${{ vars.DNS_ZONE_DOMAIN }}
+      DNS_ROUTE53_ROLE_ARN: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+      DNS_ROUTE53_ZONE_ID: ${{ vars.DNS_ROUTE53_ZONE_ID }}

--- a/.github/workflows/nightly_sonar_poc_basic_cli.yml
+++ b/.github/workflows/nightly_sonar_poc_basic_cli.yml
@@ -107,9 +107,11 @@ jobs:
       run: |
         mv $EXAMPLE_DIR/main.tf{,_}
         mv $EXAMPLE_DIR/outputs.tf{,_}
+        mv $EXAMPLE_DIR/dns.tf{,_}
         terraform -chdir=$EXAMPLE_DIR destroy -auto-approve
         mv $EXAMPLE_DIR/main.tf{_,}
         mv $EXAMPLE_DIR/outputs.tf{_,}
+        mv $EXAMPLE_DIR/dns.tf{_,}
 
       # On push to "main", build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks

--- a/.github/workflows/nightly_sonar_poc_basic_cli.yml
+++ b/.github/workflows/nightly_sonar_poc_basic_cli.yml
@@ -43,6 +43,9 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_WORKSPACE: ${{ inputs.workspace }}
   TF_VAR_additional_tags: ${{ vars.DEPLOYMENT_TAGS }}
+  TF_VAR_dns_zone_domain: ${{ vars.DNS_ZONE_DOMAIN }}
+  TF_VAR_dns_route53_role_arn: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+  TF_VAR_dns_route53_zone_id: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
 permissions:
   contents: read

--- a/.github/workflows/sonar_poc_cli.yml
+++ b/.github/workflows/sonar_poc_cli.yml
@@ -61,6 +61,9 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   DESTROY_DELAY_SECONDS: 1800
   TF_VAR_additional_tags: ${{ vars.DEPLOYMENT_TAGS }}
+  TF_VAR_dns_zone_domain: ${{ vars.DNS_ZONE_DOMAIN }}
+  TF_VAR_dns_route53_role_arn: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+  TF_VAR_dns_route53_zone_id: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
 permissions:
   contents: read

--- a/.github/workflows/sonar_upgrade.yml
+++ b/.github/workflows/sonar_upgrade.yml
@@ -22,6 +22,12 @@ on:
         required: true
       DEPLOYMENT_TAGS:
         required: true
+      DNS_ZONE_DOMAIN:
+        required: true
+      DNS_ROUTE53_ROLE_ARN:
+        required: true
+      DNS_ROUTE53_ZONE_ID:
+        required: true
 
   workflow_dispatch:
     inputs:
@@ -36,6 +42,9 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_VAR_additional_tags: ${{ vars.DEPLOYMENT_TAGS }}
+  TF_VAR_dns_zone_domain: ${{ vars.DNS_ZONE_DOMAIN }}
+  TF_VAR_dns_route53_role_arn: ${{ vars.DNS_ROUTE53_ROLE_ARN }}
+  TF_VAR_dns_route53_zone_id: ${{ vars.DNS_ROUTE53_ZONE_ID }}
 
 
 permissions:

--- a/.github/workflows/sonar_upgrade.yml
+++ b/.github/workflows/sonar_upgrade.yml
@@ -23,11 +23,11 @@ on:
       DEPLOYMENT_TAGS:
         required: true
       DNS_ZONE_DOMAIN:
-        required: false
+        required: true
       DNS_ROUTE53_ROLE_ARN:
-        required: false
+        required: true
       DNS_ROUTE53_ZONE_ID:
-        required: false
+        required: true
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sonar_upgrade.yml
+++ b/.github/workflows/sonar_upgrade.yml
@@ -182,6 +182,7 @@ jobs:
             mv $DEPLOYMENT_EXAMPLE_DIR/cm.tf{,_}
             mv $DEPLOYMENT_EXAMPLE_DIR/cte_ddc_agents.tf{,_}
             mv $DEPLOYMENT_EXAMPLE_DIR/fam_classification_integration_resources.tf{,_}
+            mv $DEPLOYMENT_EXAMPLE_DIR/dns.tf{,_}
             terraform -chdir=$DEPLOYMENT_EXAMPLE_DIR destroy -var dam_license=license.mprv -auto-approve
             mv $DEPLOYMENT_EXAMPLE_DIR/main.tf{_,}
             mv $DEPLOYMENT_EXAMPLE_DIR/outputs.tf{_,}
@@ -194,6 +195,7 @@ jobs:
             mv $DEPLOYMENT_EXAMPLE_DIR/cm.tf{_,}
             mv $DEPLOYMENT_EXAMPLE_DIR/cte_ddc_agents.tf{_,}
             mv $DEPLOYMENT_EXAMPLE_DIR/fam_classification_integration_resources.tf{_,}
+            mv $DEPLOYMENT_EXAMPLE_DIR/dns.tf{_,}
           fi
 
       - name: Terraform Validate for deployment

--- a/.github/workflows/sonar_upgrade.yml
+++ b/.github/workflows/sonar_upgrade.yml
@@ -23,11 +23,11 @@ on:
       DEPLOYMENT_TAGS:
         required: true
       DNS_ZONE_DOMAIN:
-        required: true
+        required: false
       DNS_ROUTE53_ROLE_ARN:
-        required: true
+        required: false
       DNS_ROUTE53_ZONE_ID:
-        required: true
+        required: false
 
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ Restrictions on modules may apply</td>
   </tr>
   </tr>
   <tr>
-    <td>CipherTrust Manager</td><td>2.20</td><td>2.19 - 2.20</td>
+    <td>CipherTrust Manager</td><td>2.22</td><td>2.19 - 2.22</td>
   </tr>
 </table>
 

--- a/examples/aws/poc/dsf_deployment/cm.tf
+++ b/examples/aws/poc/dsf_deployment/cm.tf
@@ -37,8 +37,8 @@ provider "ciphertrust" {
   address  = local.ciphertrust_manager_count > 0 ? "https://${coalesce(module.ciphertrust_manager[0].public_ip, module.ciphertrust_manager[0].private_ip)}" : null
   username = local.ciphertrust_manager_web_console_username
   password = local.password
-  // destroy cluster can take almost a minute so give us a bit of a buffer
-  rest_api_timeout = 720
+  // CM 2.22 cluster join can take >10 minutes; destroy can take ~1 minute
+  rest_api_timeout = 1500
 }
 
 resource "ciphertrust_trial_license" "trial_license" {

--- a/examples/aws/poc/dsf_deployment/variables.tf
+++ b/examples/aws/poc/dsf_deployment/variables.tf
@@ -384,7 +384,7 @@ variable "dra_analytics_ebs_details" {
 
 variable "ciphertrust_manager_version" {
   type        = string
-  default     = "2.20"
+  default     = "2.22"
   description = "The CipherTrust Manager version from AWS marketplace to install. Supported versions are: 2.19 and up."
   validation {
     condition     = can(regex("^\\d{1,2}\\.\\d{1,3}$", var.ciphertrust_manager_version))

--- a/modules/aws/ciphertrust-manager/sg.tf
+++ b/modules/aws/ciphertrust-manager/sg.tf
@@ -2,7 +2,7 @@ locals {
   # Skip sg creation if external sg list is given
   _security_groups_config = length(var.security_group_ids) == 0 ? local.security_groups_config : []
 
-  security_groups_config = [ // https://thalesdocs.com/ctp/cm/2.19/get_started/deployment/hardening-guidelines/index.html
+  security_groups_config = [ // https://docs-cybersec.thalesgroup.com/bundle/latest-cdsp-cm/page/get_started/deployment/hardening-guidelines/index.html
     {
       name            = ["web", "console", "and", "api"]
       internet_access = false
@@ -21,7 +21,7 @@ locals {
       name            = ["cluster", "nodes"]
       internet_access = false
       udp             = []
-      tcp             = [5432]
+      tcp             = [5432, 2380]
       cidrs           = concat(var.allowed_cluster_nodes_cidrs, var.allowed_all_cidrs)
     },
     {

--- a/modules/aws/ciphertrust-manager/variables.tf
+++ b/modules/aws/ciphertrust-manager/variables.tf
@@ -170,7 +170,7 @@ variable "ssh_user" {
 
 variable "ciphertrust_manager_version" {
   type        = string
-  default     = "2.20"
+  default     = "2.22"
   description = "The CipherTrust Manager version to install"
   validation {
     condition     = can(regex("^\\d{1,2}\\.\\d{1,3}$", var.ciphertrust_manager_version))


### PR DESCRIPTION
Update the default CipherTrust Manager version from 2.20 to 2.22 across module variables, example configurations, and README supported version range (2.19 - 2.22).