### PR TITLE
chore(aws): use wildcard pattern for RHEL 8 AMI name

### DIFF
--- a/modules/aws/db-with-agent/os_params.tf
+++ b/modules/aws/db-with-agent/os_params.tf
@@ -2,7 +2,7 @@ locals {
   os_params = {
     "Red Hat" : {
       ami_owner              = "309956199498"
-      ami_name               = "RHEL-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3"
+      ami_name               = "RHEL-8.*_HVM-*-x86_64-*-Hourly2-GP3"
       ami_ssh_user           = "ec2-user"
       agent_installation_dir = "/opt/imperva",
       installation_filename  = "Imperva-ragent-RHEL-v8-kSMP-px86_64-b14.6.0.60.0.637577.bsx"

--- a/modules/aws/sonar-base-instance/ami.tf
+++ b/modules/aws/sonar-base-instance/ami.tf
@@ -3,7 +3,7 @@ locals {
     id               = null
     owner_account_id = "309956199498"
     username         = "ec2-user"
-    name             = "RHEL-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3"
+    name             = "RHEL-8.*_HVM-*-x86_64-*-Hourly2-GP3"
   }
 
   ami = var.ami != null ? var.ami : local.ami_default


### PR DESCRIPTION
Replace pinned RHEL-8.6.0 AMI name with a wildcard pattern to automatically pick up the latest RHEL 8 HVM x86_64 image in both db-with-agent and sonar-base-instance modules.