### PR TITLE
release: decouple test_plan/test_apply from Terraform Registry indexing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,14 @@ jobs:
     needs: deploy_modules
     uses: ./.github/workflows/plan_cli.yml
     with:
-      use_modules_from_terraform_registry: true
+      # Use the in-repo modules instead of the Terraform Registry. The release
+      # flow must not depend on the registry having indexed the new tag, since
+      # the GitHub -> Terraform Registry webhook can be delayed or dropped
+      # (see release 1.7.35: tag was pushed to all per-module repos but never
+      # indexed by the registry, causing test_plan to fail with
+      # "Unresolvable module version constraint"). The in-repo modules are the
+      # same code that deploy_modules publishes to the per-module repos.
+      use_modules_from_terraform_registry: false
       explicit_ref: master
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -210,7 +217,8 @@ jobs:
     needs: release
     uses: ./.github/workflows/sonar_poc_cli.yml
     with:
-      use_modules_from_terraform_registry: true
+      # See test_plan above for rationale.
+      use_modules_from_terraform_registry: false
       explicit_ref: master
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/scripts/check_registry_versions.sh
+++ b/scripts/check_registry_versions.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# check_registry_versions.sh — Verify that the Terraform Registry has indexed
+# a given dsfkit release tag for every per-module repo.
+#
+# Background:
+# The dsfkit release flow (.github/workflows/release.yml) pushes a new tag
+# (e.g. 1.7.35) to ~25 sibling repos under github.com/imperva/terraform-*-dsf-*.
+# The Terraform Registry mirrors them via a GitHub webhook. That webhook can
+# be delayed or dropped, which is what happened in the 1.7.35 release: the
+# code was on GitHub but the registry kept the previous version as the latest.
+#
+# Usage:
+#   scripts/check_registry_versions.sh                # checks the version in main.tf
+#   scripts/check_registry_versions.sh 1.7.35         # checks an explicit version
+#
+# Exit code 0 if every module exposes the expected version on the registry,
+# non-zero otherwise (and prints a list of the modules that are still behind
+# along with the resync URL to click in the registry UI).
+
+set -euo pipefail
+
+EXPECTED="${1:-}"
+
+if [ -z "$EXPECTED" ]; then
+    if [ -f main.tf ] && grep -q 'version = ".*latest release tag' main.tf 2>/dev/null; then
+        EXPECTED=$(grep 'latest release tag' main.tf | head -1 | sed -E 's/.*version = "([^"]+)".*/\1/')
+    elif [ -f examples/aws/poc/dsf_deployment/main.tf ]; then
+        EXPECTED=$(grep 'latest release tag' examples/aws/poc/dsf_deployment/main.tf | head -1 | sed -E 's/.*version = "([^"]+)".*/\1/')
+    fi
+fi
+
+if [ -z "$EXPECTED" ]; then
+    echo "Usage: $0 <version>"
+    exit 2
+fi
+
+echo "Expected version: $EXPECTED"
+echo
+
+# Keep this list in sync with the matrix in .github/workflows/deploy_module.yml
+MODULES=(
+    # AWS provider
+    "imperva/dsf-hub/aws"
+    "imperva/dsf-agentless-gw/aws"
+    "imperva/dsf-poc-db-onboarder/aws"
+    "imperva/dsf-sonar-upgrader/aws"
+    "imperva/dsf-mx/aws"
+    "imperva/dsf-agent-gw/aws"
+    "imperva/dsf-db-with-agent/aws"
+    "imperva/dsf-dra-admin/aws"
+    "imperva/dsf-dra-analytics/aws"
+    "imperva/dsf-ciphertrust-manager/aws"
+    "imperva/dsf-cte-ddc-agent/aws"
+    "imperva/dsf-globals/aws"
+    # Azurerm provider
+    "imperva/dsf-hub/azurerm"
+    "imperva/dsf-agentless-gw/azurerm"
+    "imperva/dsf-poc-db-onboarder/azurerm"
+    "imperva/dsf-mx/azurerm"
+    "imperva/dsf-agent-gw/azurerm"
+    "imperva/dsf-db-with-agent/azurerm"
+    "imperva/dsf-dra-admin/azurerm"
+    "imperva/dsf-dra-analytics/azurerm"
+    "imperva/dsf-globals/azurerm"
+    # Null provider
+    "imperva/dsf-hadr/null"
+    "imperva/dsf-federation/null"
+    "imperva/dsf-agent-gw-cluster-setup/null"
+    "imperva/dsf-ciphertrust-manager-cluster-setup/null"
+)
+
+ok=0
+behind=()
+for m in "${MODULES[@]}"; do
+    versions=$(curl -fsSL "https://registry.terraform.io/v1/modules/${m}/versions" 2>/dev/null | jq -r '.modules[0].versions[].version' 2>/dev/null || true)
+    if echo "$versions" | grep -qx "$EXPECTED"; then
+        printf "  \xE2\x9C\x93 %s\n" "$m"
+        ok=$((ok + 1))
+    else
+        latest=$(echo "$versions" | sort -V | tail -1)
+        printf "  \xE2\x9C\x97 %-55s (latest indexed: %s)\n" "$m" "$latest"
+        behind+=("$m")
+    fi
+done
+
+echo
+echo "$ok / ${#MODULES[@]} modules have $EXPECTED indexed."
+
+if [ ${#behind[@]} -gt 0 ]; then
+    echo
+    echo "To force a resync, open each of these pages in the Terraform Registry"
+    echo "(while logged in as the imperva org owner) and click 'Manage Module ->"
+    echo "Resync Module':"
+    echo
+    for m in "${behind[@]}"; do
+        echo "  https://registry.terraform.io/modules/${m}"
+    done
+    exit 1
+fi


### PR DESCRIPTION
Release 1.7.35 was blocked because the GitHub → Terraform Registry webhook didn't index the new tag for 21 of 25 modules (had to be manually resynced one-by-one in the registry UI by the sole publisher account). Since `test_plan`/`test_apply` ran `terraform init` against the registry, they failed with `Unresolvable module version constraint`, which blocked the rest of the release flow.

This PR makes the release self-contained: `test_plan` and `test_apply` now consume the in-repo modules (the same code `deploy_modules` publishes to the per-module repos), so the registry indexing delay can no longer block a release. Customers continue to consume from `imperva/dsf-*/aws` etc. as before — registry indexing runs as a separate concern.

Also adds `scripts/check_registry_versions.sh` which lists which modules are still behind a given version on the registry and prints clickable resync URLs.
