### PR TITLE
feat(aws): enable EBS volume encryption by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,14 @@ The following table lists the _latest_ DSF Kit releases, their release date and 
         <br/>2. Added optional DNS CNAME support for AWS POC examples (dsf_deployment, sonar_basic_deployment, sonar_hadr_deployment). When configured, creates friendly DNS names for public-facing instances via Route53 cross-account. Set the 'dns_zone_domain' and optionally 'dns_route53_role_arn' and 'dns_route53_zone_id' variables to enable it. Disabled by default.
      </td>  
   </tr>
+  <tr>
+    <td>TBD
+    </td>
+    <td>1.7.36</td>
+    <td>
+        AWS EBS volumes are now encrypted by default. To opt out, set 'encrypted = false' in the relevant '*_ebs_details' / 'ebs' variable.
+     </td>  
+  </tr>
   
 </table>
 

--- a/examples/aws/installation/dsf_single_account_deployment/variables.tf
+++ b/examples/aws/installation/dsf_single_account_deployment/variables.tf
@@ -302,12 +302,14 @@ variable "hub_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Hub compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 250
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 
@@ -316,12 +318,14 @@ variable "agentless_gw_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Agentless Gateway compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 
@@ -492,11 +496,13 @@ variable "mx_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "MX compute instance volume attributes"
   default = {
     volume_size = 160
     volume_type = "gp2"
+    encrypted   = true
   }
 }
 
@@ -504,11 +510,13 @@ variable "agent_gw_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "Agent Gateway compute instance volume attributes"
   default = {
     volume_size = 160
     volume_type = "gp2"
+    encrypted   = true
   }
 }
 
@@ -584,11 +592,13 @@ variable "dra_admin_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "DRA Admin compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.11-data-risk-analytics-installation-guide/page/69846.htm"
   default = {
     volume_size = 260
     volume_type = "gp3"
+    encrypted   = true
   }
 }
 
@@ -596,11 +606,13 @@ variable "dra_analytics_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "DRA Analytics compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.11-data-risk-analytics-installation-guide/page/69846.htm"
   default = {
     volume_size = 1010
     volume_type = "gp3"
+    encrypted   = true
   }
 }
 

--- a/examples/aws/installation/sonar_multi_account_deployment/variables.tf
+++ b/examples/aws/installation/sonar_multi_account_deployment/variables.tf
@@ -172,12 +172,14 @@ variable "hub_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Hub compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 500
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 
@@ -186,12 +188,14 @@ variable "agentless_gw_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "Agentless Gateway compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 

--- a/examples/aws/installation/sonar_single_account_deployment/variables.tf
+++ b/examples/aws/installation/sonar_single_account_deployment/variables.tf
@@ -119,12 +119,14 @@ variable "hub_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Hub compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 500
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 
@@ -133,12 +135,14 @@ variable "agentless_gw_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "Agentless Gateway compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 

--- a/examples/aws/poc/dsf_deployment/cm.tf
+++ b/examples/aws/poc/dsf_deployment/cm.tf
@@ -5,8 +5,7 @@ locals {
 }
 
 module "ciphertrust_manager" {
-  source                      = "imperva/dsf-ciphertrust-manager/aws"
-  version                     = "1.7.35" # latest release tag
+  source                      = "../../../../modules/aws/ciphertrust-manager" # TEST OVERRIDE — revert to: source = "imperva/dsf-ciphertrust-manager/aws", version = "1.7.35"
   count                       = local.ciphertrust_manager_count
   ciphertrust_manager_version = var.ciphertrust_manager_version
   ami = var.ciphertrust_manager_ami_id == null ? null : {

--- a/examples/aws/poc/dsf_deployment/cm.tf
+++ b/examples/aws/poc/dsf_deployment/cm.tf
@@ -5,7 +5,8 @@ locals {
 }
 
 module "ciphertrust_manager" {
-  source                      = "../../../../modules/aws/ciphertrust-manager" # TEST OVERRIDE — revert to: source = "imperva/dsf-ciphertrust-manager/aws", version = "1.7.35"
+  source = "imperva/dsf-ciphertrust-manager/aws"
+  version = "1.7.35"
   count                       = local.ciphertrust_manager_count
   ciphertrust_manager_version = var.ciphertrust_manager_version
   ami = var.ciphertrust_manager_ami_id == null ? null : {

--- a/examples/aws/poc/dsf_deployment/cm.tf
+++ b/examples/aws/poc/dsf_deployment/cm.tf
@@ -5,8 +5,8 @@ locals {
 }
 
 module "ciphertrust_manager" {
-  source = "imperva/dsf-ciphertrust-manager/aws"
-  version = "1.7.35"
+  source  = "imperva/dsf-ciphertrust-manager/aws"
+  version = "1.7.35" # latest release tag
   count                       = local.ciphertrust_manager_count
   ciphertrust_manager_version = var.ciphertrust_manager_version
   ami = var.ciphertrust_manager_ami_id == null ? null : {

--- a/examples/aws/poc/dsf_deployment/variables.tf
+++ b/examples/aws/poc/dsf_deployment/variables.tf
@@ -199,11 +199,13 @@ variable "mx_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "MX compute instance volume attributes"
   default = {
     volume_size = 160
     volume_type = "gp2"
+    encrypted   = true
   }
 }
 
@@ -211,11 +213,13 @@ variable "agent_gw_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "Agent Gateway compute instance volume attributes"
   default = {
     volume_size = 160
     volume_type = "gp2"
+    encrypted   = true
   }
 }
 
@@ -300,11 +304,13 @@ variable "hub_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   default = {
     disk_size        = 250
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
   description = "DSF Hub compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
 }
@@ -314,11 +320,13 @@ variable "agentless_gw_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   default = {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
   description = "DSF Agentless Gateway compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
 }
@@ -358,11 +366,13 @@ variable "dra_admin_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "DRA Admin compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.11-data-risk-analytics-installation-guide/page/69846.htm"
   default = {
     volume_size = 260
     volume_type = "gp3"
+    encrypted   = true
   }
 }
 
@@ -370,11 +380,13 @@ variable "dra_analytics_ebs_details" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
   description = "DRA Analytics compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.11-data-risk-analytics-installation-guide/page/69846.htm"
   default = {
     volume_size = 1010
     volume_type = "gp3"
+    encrypted   = true
   }
 }
 
@@ -407,12 +419,14 @@ variable "ciphertrust_manager_ebs_details" {
     volume_size = number
     volume_type = string
     iops        = number
+    encrypted   = optional(bool, true)
   })
   description = "CipherTrust Manager compute instance volume attributes"
   default = {
     volume_size = 300
     volume_type = "gp3"
     iops        = 3000
+    encrypted   = true
   }
 }
 
@@ -421,12 +435,14 @@ variable "cte_ddc_agent_ebs_details" {
     volume_size = number
     volume_type = string
     iops        = number
+    encrypted   = optional(bool, true)
   })
   description = "CTE and/or DDC agent compute instance volume attributes"
   default = {
     volume_size = 30
     volume_type = "gp3"
     iops        = 3000
+    encrypted   = true
   }
 }
 

--- a/examples/aws/poc/sonar_basic_deployment/variables.tf
+++ b/examples/aws/poc/sonar_basic_deployment/variables.tf
@@ -109,12 +109,14 @@ variable "hub_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Hub compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 250
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 
@@ -123,12 +125,14 @@ variable "agentless_gw_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Agentless Gateway compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 

--- a/examples/aws/poc/sonar_hadr_deployment/variables.tf
+++ b/examples/aws/poc/sonar_hadr_deployment/variables.tf
@@ -147,12 +147,14 @@ variable "hub_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Hub compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 500
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 
@@ -161,12 +163,14 @@ variable "agentless_gw_ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
   description = "DSF Agentless Gateway compute instance volume attributes. More info in sizing doc - https://docs.imperva.com/bundle/v4.10-sonar-installation-and-setup-guide/page/78729.htm"
   default = {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true
   }
 }
 

--- a/modules/aws/agent-gw/variables.tf
+++ b/modules/aws/agent-gw/variables.tf
@@ -90,11 +90,13 @@ variable "ebs" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the Agentless Gateway"
+  description = "Compute instance volume attributes for the Agent Gateway. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
   default = {
     volume_size = 160
     volume_type = "gp2"
+    encrypted   = true
   }
 }
 

--- a/modules/aws/agentless-gw/README.md
+++ b/modules/aws/agentless-gw/README.md
@@ -32,7 +32,7 @@ The following input variables are **required**:
 * `subnet_id`: The ID of the subnet in which to launch the Agentless Gateway instance
 * `ssh_key_pair`: AWS key pair name and path for ssh connectivity
 * `password`: Initial password for all users
-* `ebs`: AWS EBS details
+* `ebs`: AWS EBS details. Includes an optional `encrypted` field (defaults to `true`); the root and external EBS volumes are encrypted by default using the account default EBS KMS key. Set to `false` to opt out
 * `binaries_location`: S3 DSF installation location
 * `hub_sonarw_public_key`: Public key of the sonarw user taken from the main DSF Hub output
 * `allowed_hub_cidrs`: List of ingress CIDR patterns allowing other hubs to access the DSF hub instance
@@ -78,6 +78,7 @@ module "dsf_agentless_gw" {
     disk_size        = 150
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true  # set to false to opt out of encrypting root + external EBS volumes
   }
   binaries_location                 = {
     s3_bucket        = "my_S3_bucket"

--- a/modules/aws/agentless-gw/variables.tf
+++ b/modules/aws/agentless-gw/variables.tf
@@ -116,8 +116,9 @@ variable "ebs" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
-  description = "Compute instance volume attributes"
+  description = "Compute instance volume attributes. Both the root and external EBS volumes are encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
 }
 
 variable "ingress_communication_via_proxy" {

--- a/modules/aws/ciphertrust-manager/README.md
+++ b/modules/aws/ciphertrust-manager/README.md
@@ -29,7 +29,7 @@ The following input variables are **required**:
 
 * `subnet_id`: The subnet ID to attach the CipherTrust instance to.
 * `key_pair`: Name of the AWS EC2 key pair used for SSH access.
-* `ebs`: AWS EBS details.
+* `ebs`: AWS EBS details. Includes an optional `encrypted` field (defaults to `true`); the root EBS volume is encrypted by default using the account default EBS KMS key. Set to `false` to opt out.
 
 Additionally, the following variables are often **required unless defaults suffice**:
 
@@ -65,6 +65,7 @@ module "dsf_ciphertrust_manager" {
     volume_size = 300
     volume_type = "gp3"
     iops        = 3000
+    encrypted   = true  # set to false to opt out of encrypting the root EBS volume
   }
 
   allowed_web_console_and_api_cidrs = ["10.0.0.0/24"]

--- a/modules/aws/ciphertrust-manager/main.tf
+++ b/modules/aws/ciphertrust-manager/main.tf
@@ -37,6 +37,7 @@ resource "aws_instance" "cipthertrust_manager_instance" {
     volume_size           = var.ebs.volume_size
     volume_type           = var.ebs.volume_type
     iops                  = var.ebs.iops
+    encrypted             = var.ebs.encrypted
     delete_on_termination = true
   }
   network_interface {

--- a/modules/aws/ciphertrust-manager/variables.tf
+++ b/modules/aws/ciphertrust-manager/variables.tf
@@ -148,8 +148,9 @@ variable "ebs" {
     volume_size = number
     volume_type = string
     iops        = number
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the CipherTrust Manager"
+  description = "Compute instance volume attributes for the CipherTrust Manager. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
 }
 
 variable "attach_persistent_public_ip" {

--- a/modules/aws/cte-ddc-agent/main.tf
+++ b/modules/aws/cte-ddc-agent/main.tf
@@ -55,6 +55,7 @@ resource "aws_instance" "cte_ddc_agent" {
     volume_size           = var.ebs.volume_size
     volume_type           = var.ebs.volume_type
     iops                  = var.ebs.iops
+    encrypted             = var.ebs.encrypted
     delete_on_termination = true
   }
   user_data = local.user_data

--- a/modules/aws/cte-ddc-agent/variables.tf
+++ b/modules/aws/cte-ddc-agent/variables.tf
@@ -23,8 +23,9 @@ variable "ebs" {
     volume_size = number
     volume_type = string
     iops        = number
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the agent instance"
+  description = "Compute instance volume attributes for the agent instance. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
 }
 
 variable "subnet_id" {

--- a/modules/aws/dam-base-instance/main.tf
+++ b/modules/aws/dam-base-instance/main.tf
@@ -45,6 +45,7 @@ resource "aws_instance" "dsf_base_instance" {
   root_block_device {
     volume_size           = var.ebs.volume_size
     volume_type           = var.ebs.volume_type
+    encrypted             = var.ebs.encrypted
     delete_on_termination = true
   }
   iam_instance_profile = local.instance_profile

--- a/modules/aws/dam-base-instance/variables.tf
+++ b/modules/aws/dam-base-instance/variables.tf
@@ -51,8 +51,9 @@ variable "ebs" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the DAM base instance"
+  description = "Compute instance volume attributes for the DAM base instance. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
 }
 
 variable "instance_profile_name" {

--- a/modules/aws/dra-admin/main.tf
+++ b/modules/aws/dra-admin/main.tf
@@ -38,6 +38,7 @@ resource "aws_instance" "dsf_base_instance" {
   root_block_device {
     volume_size           = var.ebs.volume_size
     volume_type           = var.ebs.volume_type
+    encrypted             = var.ebs.encrypted
     delete_on_termination = true
   }
   iam_instance_profile = local.instance_profile

--- a/modules/aws/dra-admin/variables.tf
+++ b/modules/aws/dra-admin/variables.tf
@@ -179,11 +179,13 @@ variable "ebs" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the DRA Admin"
+  description = "Compute instance volume attributes for the DRA Admin. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
   default = {
     volume_size = 260
     volume_type = "gp3"
+    encrypted   = true
   }
 }
 

--- a/modules/aws/dra-analytics/main.tf
+++ b/modules/aws/dra-analytics/main.tf
@@ -32,6 +32,7 @@ resource "aws_instance" "dsf_base_instance" {
   root_block_device {
     volume_size           = var.ebs.volume_size
     volume_type           = var.ebs.volume_type
+    encrypted             = var.ebs.encrypted
     delete_on_termination = true
   }
   iam_instance_profile = local.instance_profile

--- a/modules/aws/dra-analytics/variables.tf
+++ b/modules/aws/dra-analytics/variables.tf
@@ -194,11 +194,13 @@ variable "ebs" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the DRA Analytics"
+  description = "Compute instance volume attributes for the DRA Analytics. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
   default = {
     volume_size = 1010
     volume_type = "gp3"
+    encrypted   = true
   }
 }
 

--- a/modules/aws/hub/README.md
+++ b/modules/aws/hub/README.md
@@ -31,7 +31,7 @@ The following input variables are **required**:
 * `subnet_id`: The ID of the subnet in which to launch the DSF Hub instance
 * `ssh_key_pair`: AWS key pair name and path for ssh connectivity
 * `password`: Initial password for all users
-* `ebs`: AWS EBS details
+* `ebs`: AWS EBS details. Includes an optional `encrypted` field (defaults to `true`); the root and external EBS volumes are encrypted by default using the account default EBS KMS key. Set to `false` to opt out
 * `binaries_location`: S3 DSF installation location
 * `allowed_web_console_and_api_cidrs`: List of ingress CIDR patterns allowing web console access
 * `allowed_hub_cidrs`: List of ingress CIDR patterns allowing other hubs to access the DSF hub instance
@@ -77,6 +77,7 @@ module "dsf_hub" {
     disk_size        = 500
     provisioned_iops = 0
     throughput       = 125
+    encrypted        = true  # set to false to opt out of encrypting root + external EBS volumes
   }
   binaries_location                 = {
     s3_bucket        = "my_S3_bucket"

--- a/modules/aws/hub/variables.tf
+++ b/modules/aws/hub/variables.tf
@@ -114,8 +114,9 @@ variable "ebs" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
-  description = "Compute instance volume attributes"
+  description = "Compute instance volume attributes. Both the root and external EBS volumes are encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
 }
 
 variable "ingress_communication_via_proxy" {

--- a/modules/aws/mx/variables.tf
+++ b/modules/aws/mx/variables.tf
@@ -25,11 +25,13 @@ variable "ebs" {
   type = object({
     volume_size = number
     volume_type = string
+    encrypted   = optional(bool, true)
   })
-  description = "Compute instance volume attributes for the MX"
+  description = "Compute instance volume attributes for the MX. The root EBS volume is encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
   default = {
     volume_size = 160
     volume_type = "gp2"
+    encrypted   = true
   }
 }
 

--- a/modules/aws/sonar-base-instance/main.tf
+++ b/modules/aws/sonar-base-instance/main.tf
@@ -43,6 +43,7 @@ resource "aws_instance" "dsf_base_instance" {
   user_data     = local.install_script
   root_block_device {
     volume_size = local.root_volume_size
+    encrypted   = var.ebs_details.encrypted
   }
   iam_instance_profile = local.instance_profile
   network_interface {
@@ -72,6 +73,7 @@ resource "aws_ebs_volume" "ebs_external_data_vol" {
   type              = local.ebs_state_disk_type
   iops              = local.ebs_state_iops
   throughput        = local.ebs_state_throughput
+  encrypted         = var.ebs_details.encrypted
   availability_zone = data.aws_subnet.selected_subnet.availability_zone
   tags              = merge(var.tags, { Name = join("-", [var.name, "data", "volume", "ebs"]) })
   lifecycle {

--- a/modules/aws/sonar-base-instance/variables.tf
+++ b/modules/aws/sonar-base-instance/variables.tf
@@ -68,8 +68,9 @@ variable "ebs_details" {
     disk_size        = number
     provisioned_iops = number
     throughput       = number
+    encrypted        = optional(bool, true)
   })
-  description = "Compute instance external volume attributes"
+  description = "Compute instance external volume attributes. Both the root and external EBS volumes are encrypted by default (using the account default EBS KMS key). Set 'encrypted' to false to opt out."
   validation {
     condition     = var.ebs_details.disk_size >= 150
     error_message = "Disk size must be at least 150 GB"


### PR DESCRIPTION
Add `encrypted` attribute (default: true) to all `*_ebs_details` and `ebs` variables across AWS deployment examples and modules. This ensures EBS volumes for Hub, Agentless Gateway, MX, Agent Gateway, DRA, CTE/DDC, and related components are encrypted by default.

Users can opt out by setting `encrypted = false` in the relevant variable. Release notes updated for version 1.7.36.