### PR TITLE
fix(azure): broaden RHUI repo disable pattern for azure-cli install

### DIFF
--- a/modules/azurerm/sonar-base-instance/setup.tftpl
+++ b/modules/azurerm/sonar-base-instance/setup.tftpl
@@ -91,7 +91,7 @@ function install_azcli_from_internet() {
     # Fall back to disabling RHUI if it's degraded; azure-cli's RHEL-side deps
     # are already in the Azure RHEL PAYG base image.
     yum_retry dnf install azure-cli -y \
-        || yum_retry dnf install azure-cli -y --disablerepo='rhui-*'
+        || yum_retry dnf install azure-cli -y --disablerepo='*rhui*'
 
     az login --identity --allow-no-subscriptions
 }


### PR DESCRIPTION
Update the `--disablerepo` glob from `rhui-*` to `*rhui*` to match RHUI repositories with varying naming conventions, ensuring the azure-cli fallback install succeeds on a wider range of RHEL PAYG images.