### PR TITLE
fix(azure): harden azure-cli install against degraded RHUI

### DIFF
--- a/modules/azurerm/dra-admin/setup.tftpl
+++ b/modules/azurerm/dra-admin/setup.tftpl
@@ -24,21 +24,27 @@ function dnf_retry(){
 
 function install-azure-cli(){
   dnf_retry rpm --import https://packages.microsoft.com/keys/microsoft.asc
-  # Install only the packages-microsoft-prod RPM that matches the running
-  # RHEL major version. Previously we attempted both RHEL 8 and RHEL 9
-  # variants and tolerated the failing one with `|| true`, but combined
-  # with dnf_retry that wasted up to ~5 minutes of bounded retries on the
-  # impossible install -- enough to push past the downstream null_resource
-  # readiness timeout.
+
+  local msrepo_url
   if [ "$RHEL_MAJOR_VERSION" = "9" ]; then
-    dnf_retry dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+    msrepo_url="https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm"
   elif [ "$RHEL_MAJOR_VERSION" = "8" ]; then
-    dnf_retry dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+    msrepo_url="https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm"
   else
     echo "Unsupported RHEL version: $RHEL_MAJOR_VERSION"
     exit 1
   fi
-  dnf_retry dnf install azure-cli -y
+
+  # rpm -Uvh avoids dnf's mandatory metadata refresh, which fails when
+  # Azure RHUI returns 400 on rhel-*-baseos-rhui-rpms.
+  dnf_retry rpm -Uvh --replacepkgs "$msrepo_url"
+
+  # Fall back to disabling RHUI if it's degraded; --nobest lets dnf pick the
+  # newest azure-cli whose python pin matches what's already in the Azure
+  # RHEL PAYG base image (python3.9) when the appstream repo is unreachable.
+  dnf_retry dnf install azure-cli -y \
+    || dnf_retry dnf install azure-cli -y --disablerepo='*rhui*' --nobest
+
   az login --identity
 }
 

--- a/modules/azurerm/dra-analytics/setup.tftpl
+++ b/modules/azurerm/dra-analytics/setup.tftpl
@@ -30,21 +30,27 @@ function dnf_retry(){
 
 function install-azure-cli(){
   dnf_retry rpm --import https://packages.microsoft.com/keys/microsoft.asc
-  # Install only the packages-microsoft-prod RPM that matches the running
-  # RHEL major version. Previously we attempted both RHEL 8 and RHEL 9
-  # variants and tolerated the failing one with `|| true`, but combined
-  # with dnf_retry that wasted up to ~5 minutes of bounded retries on the
-  # impossible install -- enough to push past the downstream null_resource
-  # readiness timeout.
+
+  local msrepo_url
   if [ "$RHEL_MAJOR_VERSION" = "9" ]; then
-    dnf_retry dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+    msrepo_url="https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm"
   elif [ "$RHEL_MAJOR_VERSION" = "8" ]; then
-    dnf_retry dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+    msrepo_url="https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm"
   else
     echo "Unsupported RHEL version: $RHEL_MAJOR_VERSION"
     exit 1
   fi
-  dnf_retry dnf install azure-cli -y
+
+  # rpm -Uvh avoids dnf's mandatory metadata refresh, which fails when
+  # Azure RHUI returns 400 on rhel-*-baseos-rhui-rpms.
+  dnf_retry rpm -Uvh --replacepkgs "$msrepo_url"
+
+  # Fall back to disabling RHUI if it's degraded; --nobest lets dnf pick the
+  # newest azure-cli whose python pin matches what's already in the Azure
+  # RHEL PAYG base image (python3.9) when the appstream repo is unreachable.
+  dnf_retry dnf install azure-cli -y \
+    || dnf_retry dnf install azure-cli -y --disablerepo='*rhui*' --nobest
+
   az login --identity
 }
 

--- a/modules/azurerm/sonar-base-instance/setup.tftpl
+++ b/modules/azurerm/sonar-base-instance/setup.tftpl
@@ -91,7 +91,7 @@ function install_azcli_from_internet() {
     # Fall back to disabling RHUI if it's degraded; azure-cli's RHEL-side deps
     # are already in the Azure RHEL PAYG base image.
     yum_retry dnf install azure-cli -y \
-        || yum_retry dnf install azure-cli -y --disablerepo='*rhui*'
+        || yum_retry dnf install azure-cli -y --disablerepo='*rhui*' --nobest
 
     az login --identity --allow-no-subscriptions
 }


### PR DESCRIPTION
Use `rpm -Uvh` to install the Microsoft repo RPM in DRA admin/analytics setup scripts, avoiding dnf's mandatory metadata refresh which fails when Azure RHUI returns 400 on rhel-*-baseos-rhui-rpms. Add a fallback that disables RHUI repos and uses `--nobest` to pick an azure-cli build matching the base image's python3.9 when the appstream repo is unreachable.

Also add `--nobest` to the sonar-base-instance RHUI fallback for consistency.